### PR TITLE
Feature/add search using lexicon

### DIFF
--- a/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/base.html
+++ b/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/base.html
@@ -201,6 +201,7 @@
                         url: "{{ autocomplete_api_url }}",
                         data: {
                             q: request.term,
+                            l: $("#selected_lex :selected").text(),
                             limit: 5
                         },
                         success: function (json) {

--- a/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
+++ b/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
@@ -2,14 +2,14 @@
     <div class="input-group rg-search">
         <label class="sr-only" for="input-search">Término a buscar</label>
         <input id="input-search" class="ui-widget form-control" name="q" type="text" value="{{ query }}">
-        <select name="l">
+        <select id="selected_lex" name="l">
             {% for lex_list_by_src in lexicons %}
                 <optgroup label="{{ lex_list_by_src.0.src_language }}"> 
                 {% for lex in lex_list_by_src %}
-                    {% if lex.name == selected_lexicon %}
-                        <option selected value="{{ lex.name }}">{{ lex.name }}</option>
+                    {% if lex.code == selected_lexicon %}
+                        <option selected value="{{ lex.code }}">{{ lex.code }}</option>
                     {% else %}
-                        <option value="{{ lex.name }}">{{ lex.name }}</option> 
+                        <option value="{{ lex.code }}">{{ lex.code }}</option> 
                     {% endif %}
                 {% endfor %}
             {% empty %}

--- a/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
+++ b/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
@@ -3,9 +3,12 @@
         <label class="sr-only" for="input-search">Término a buscar</label>
         <input id="input-search" class="ui-widget form-control" name="q" type="text" value="{{ query }}">
         <select name="l">
-            {% if lexicon_names %}
-                {% for lex in lexicons %}
-                    <option value="{{ lex.name }}">{{ lex.name }}</option> 
+            {% if lexicons %}
+                {% for lex_list_by_src in lexicons %}
+                    <optgroup label="{{ lex_list_by_src.0.src_language }}"> 
+                    {% for lex in lex_list_by_src %}
+                        <option value="{{ lex.name }}">{{ lex.name }}</option> 
+                    {% endfor %}
                 {% endfor %}
             {% else %}
                 <option selected value=''>Empty Value</option>

--- a/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
+++ b/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
@@ -3,16 +3,14 @@
         <label class="sr-only" for="input-search">Término a buscar</label>
         <input id="input-search" class="ui-widget form-control" name="q" type="text" value="{{ query }}">
         <select name="l">
-            {% if lexicons %}
-                {% for lex_list_by_src in lexicons %}
-                    <optgroup label="{{ lex_list_by_src.0.src_language }}"> 
-                    {% for lex in lex_list_by_src %}
-                        <option value="{{ lex.name }}">{{ lex.name }}</option> 
-                    {% endfor %}
+            {% for lex_list_by_src in lexicons %}
+                <optgroup label="{{ lex_list_by_src.0.src_language }}"> 
+                {% for lex in lex_list_by_src %}
+                    <option value="{{ lex.name }}">{{ lex.name }}</option> 
                 {% endfor %}
-            {% else %}
-                <option selected value=''>Empty Value</option>
-            {% endif %}
+            {% empty %}
+            <option selected value=''>Empty Value</option>
+            {% endfor %}
         </select>
         <div class="input-group-append">
             <button class="btn btn-outline-secondary" type="submit" id="button-search"><i

--- a/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
+++ b/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
@@ -4,8 +4,8 @@
         <input id="input-search" class="ui-widget form-control" name="q" type="text" value="{{ query }}">
         <select name="l">
             {% if lexicon_names %}
-                {% for lexicon_name in lexicon_names %}
-                    <option selected value=lexicon_name>{{ lexicon_name.name }}</option> 
+                {% for lex in lexicons %}
+                    <option value='{{ lex.name }}'>{{ lex.name }}</option> 
                 {% endfor %}
             {% else %}
                 <option selected value=''>Empty Value</option>

--- a/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
+++ b/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
@@ -2,6 +2,15 @@
     <div class="input-group rg-search">
         <label class="sr-only" for="input-search">Término a buscar</label>
         <input id="input-search" class="ui-widget form-control" name="q" type="text" value="{{ query }}">
+        <select name="l">
+            {% if lexicon_names %}
+                {% for lexicon_name in lexicon_names %}
+                    <option selected value=lexicon_name>{{ lexicon_name.name }}</option> 
+                {% endfor %}
+            {% else %}
+                <option selected value=''>Empty Value</option>
+            {% endif %}
+        </select>
         <div class="input-group-append">
             <button class="btn btn-outline-secondary" type="submit" id="button-search"><i
                     class="{{ fa_class }} fa-search fa-2x" aria-hidden="true"></i></button>

--- a/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
+++ b/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
@@ -6,7 +6,11 @@
             {% for lex_list_by_src in lexicons %}
                 <optgroup label="{{ lex_list_by_src.0.src_language }}"> 
                 {% for lex in lex_list_by_src %}
-                    <option value="{{ lex.name }}">{{ lex.name }}</option> 
+                    {% if lex.name == selected_lexicon %}
+                        <option selected value="{{ lex.name }}">{{ lex.name }}</option>
+                    {% else %}
+                        <option value="{{ lex.name }}">{{ lex.name }}</option> 
+                    {% endif %}
                 {% endfor %}
             {% empty %}
             <option selected value=''>Empty Value</option>

--- a/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
+++ b/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/search-tools.html
@@ -5,7 +5,7 @@
         <select name="l">
             {% if lexicon_names %}
                 {% for lex in lexicons %}
-                    <option value='{{ lex.name }}'>{{ lex.name }}</option> 
+                    <option value="{{ lex.name }}">{{ lex.name }}</option> 
                 {% endfor %}
             {% else %}
                 <option selected value=''>Empty Value</option>

--- a/linguatec_lexicon_frontend/utils.py
+++ b/linguatec_lexicon_frontend/utils.py
@@ -27,12 +27,12 @@ def retrieve_gramcats():
     return gramcats
 
 
-def retrieve_near_words(query):
+def retrieve_near_words(query, lex):
     """Retrieve near words of a query string through the API."""
     api_url = settings.LINGUATEC_LEXICON_API_URL
     client = coreapi.Client()
     schema = client.get(api_url)
-    querystring_args = {'q': query}
+    querystring_args = {'q': query, 'l': lex}
     url = schema['words'] + 'near/?' + urllib.parse.urlencode(querystring_args)
     response = client.get(url)
     results = response["results"]

--- a/linguatec_lexicon_frontend/views.py
+++ b/linguatec_lexicon_frontend/views.py
@@ -160,6 +160,11 @@ class SearchView(LinguatecBaseView):
             api_url = settings.LINGUATEC_LEXICON_API_URL
             client = coreapi.Client()
             schema = client.get(api_url)
+            
+            url = schema['lexicon'] + 'get_lexicon_names/'
+            response = client.get(url)
+            lexicons = response["results"]
+
             querystring_args = {'q': query, 'l': lex}
             url = schema['words'] + 'search/?' + \
                 urllib.parse.urlencode(querystring_args)
@@ -169,17 +174,11 @@ class SearchView(LinguatecBaseView):
             for word in results:
                 self.groupby_word_entries(word)
 
-
-            url = schema['lexicon'] + 'get_lexicon_names/'
-            response = client.get(url)
-            lexicon_names = response["results"]
-
-
             context.update({
                 'query': query,
                 'results': results,
                 'lex': lex,
-                'lexicon_names': lexicon_names,
+                'lexicons': lexicons,
             })
 
             if response["count"] == 0:

--- a/linguatec_lexicon_frontend/views.py
+++ b/linguatec_lexicon_frontend/views.py
@@ -108,7 +108,7 @@ class HomeView(LinguatecBaseView):
         for source_language in src_languages:
             res.append([])
             for lex in lexicons:
-                if source_language == lex.src_language:
+                if source_language == lex.get('src_language'):
                     res[count].append(lex)
             count=+1
         return res
@@ -129,8 +129,8 @@ class HomeView(LinguatecBaseView):
 
         src_languages = []
         for lexicon in lexicons:
-            if lexicon.src_language not in src_languages:
-                src_languages.append(lexicon.src_language)
+            if lexicon.get('src_language') not in src_languages:
+                src_languages.append(lexicon.get('src_language'))
 
         lexicons = self.order_lexicons(src_languages, lexicons)
 
@@ -177,7 +177,7 @@ class SearchView(LinguatecBaseView):
         for source_language in src_languages:
             res.append([])
             for lex in lexicons:
-                if source_language == lex.src_language:
+                if source_language == lex.get('src_language'):
                     res[count].append(lex)
             count=+1
         return res
@@ -198,8 +198,8 @@ class SearchView(LinguatecBaseView):
 
             src_languages = []
             for lexicon in lexicons:
-                if lexicon.src_language not in src_languages:
-                    src_languages.append(lexicon.src_language)
+                if lexicon.get('src_language') not in src_languages:
+                    src_languages.append(lexicon.get('src_language'))
 
             lexicons = self.order_lexicons(src_languages, lexicons)
 

--- a/linguatec_lexicon_frontend/views.py
+++ b/linguatec_lexicon_frontend/views.py
@@ -177,7 +177,6 @@ class SearchView(LinguatecBaseView):
             context.update({
                 'query': query,
                 'results': results,
-                'lex': lex,
                 'lexicons': lexicons,
             })
 

--- a/linguatec_lexicon_frontend/views.py
+++ b/linguatec_lexicon_frontend/views.py
@@ -102,6 +102,17 @@ class LinguatecBaseView(TemplateView):
 class HomeView(LinguatecBaseView):
     template_name = 'linguatec_lexicon_frontend/home.html'
 
+    def order_lexicons(self, src_languages, lexicons):
+        res=[]
+        count=0
+        for source_language in src_languages:
+            res.append([])
+            for lex in lexicons:
+                if source_language == lex.src_languages:
+                    res[count].append(lex)
+            count=+1
+        return res
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
@@ -114,10 +125,18 @@ class HomeView(LinguatecBaseView):
         schema = client.get(api_url)
         url = schema['lexicon'] + 'get_lexicon_names/'
         response = client.get(url)
-        lexicon_names = response["results"]
+        lexicons = response["results"]
+
+        src_languages = []
+        for lexicon in lexicons:
+            if lexicon.src_language not in src_languages:
+                src_languages.append(lexicon.src_language)
+
+        lexicons = self.order_lexicons(src_languages, lexicons)
+
 
         context.update({
-            'lexicon_names': lexicon_names,
+            'lexicons': lexicons,
         })
         
         return context
@@ -151,6 +170,18 @@ class PrivacyPolicy(LinguatecBaseView):
 class SearchView(LinguatecBaseView):
     template_name = "linguatec_lexicon_frontend/search_results.html"
 
+
+    def order_lexicons(self, src_languages, lexicons):
+        res=[]
+        count=0
+        for source_language in src_languages:
+            res.append([])
+            for lex in lexicons:
+                if source_language == lex.src_languages:
+                    res[count].append(lex)
+            count=+1
+        return res
+
     def dispatch(self, request, *args, **kwargs):
         """Search and show results. If none, show near words."""
         context = self.get_context_data(**kwargs)
@@ -164,6 +195,14 @@ class SearchView(LinguatecBaseView):
             url = schema['lexicon'] + 'get_lexicon_names/'
             response = client.get(url)
             lexicons = response["results"]
+
+            src_languages = []
+            for lexicon in lexicons:
+                if lexicon.src_language not in src_languages:
+                    src_languages.append(lexicon.src_language)
+
+            lexicons = self.order_lexicons(src_languages, lexicons)
+
 
             querystring_args = {'q': query, 'l': lex}
             url = schema['words'] + 'search/?' + \

--- a/linguatec_lexicon_frontend/views.py
+++ b/linguatec_lexicon_frontend/views.py
@@ -208,11 +208,11 @@ class SearchView(LinguatecBaseView):
             context.update({
                 'query': query,
                 'results': results,
+                'selected_lexicon': lex_name,
                 'lexicons': lexicons,
             })
-
             if response["count"] == 0:
-                context["near_words"] = utils.retrieve_near_words(query)
+                context["near_words"] = utils.retrieve_near_words(query, lex_name)
 
         return TemplateResponse(request, 'linguatec_lexicon_frontend/search_results.html', context)
 

--- a/linguatec_lexicon_frontend/views.py
+++ b/linguatec_lexicon_frontend/views.py
@@ -108,7 +108,7 @@ class HomeView(LinguatecBaseView):
         for source_language in src_languages:
             res.append([])
             for lex in lexicons:
-                if source_language == lex.src_languages:
+                if source_language == lex.src_language:
                     res[count].append(lex)
             count=+1
         return res
@@ -177,7 +177,7 @@ class SearchView(LinguatecBaseView):
         for source_language in src_languages:
             res.append([])
             for lex in lexicons:
-                if source_language == lex.src_languages:
+                if source_language == lex.src_language:
                     res[count].append(lex)
             count=+1
         return res


### PR DESCRIPTION
Added a displayable list to choose between the different lexicons to do the search, if there are not lexicons to display, in order to avoid problems a field "Empty value" appears.

(Done) -- > Already working in adding labels of source languages to order the lexicon names in the displayable list, but I create this pull request for letting check if there are any errors

Test made from this last feature of ordering names by source language, see next image. (Ignore the test names)

![image](https://user-images.githubusercontent.com/64277128/98716332-b04a0780-238b-11eb-9f0e-55e38a71fcce.png)

## TODO
- [x] Update JS automplete to query only selected lexicon.